### PR TITLE
Add ability to skip mail delivery

### DIFF
--- a/lib/drill/mail/default.rb
+++ b/lib/drill/mail/default.rb
@@ -6,12 +6,16 @@ module Drill
   module Mail
     class Default < Base
       def deliver
+        return if params.skip_delivery
+
         template_name = params.template_name
 
         Drill.client.messages.send_template(template_name, [], message_hash)
       end
 
       def deliver_later
+        return if params.skip_delivery
+
         template_name = params.template_name
 
         Drill::DeliveryWorker.perform_async(template_name, message_hash)

--- a/lib/drill/params.rb
+++ b/lib/drill/params.rb
@@ -2,7 +2,14 @@
 
 module Drill
   Params = Struct.new(
-    :from_name, :from_email, :reply_to, :cc, :to, :vars, :template_name,
+    :from_name,
+    :from_email,
+    :reply_to,
+    :cc,
+    :to,
+    :vars,
+    :template_name,
+    :skip_delivery,
     keyword_init: true
   ) do
     def merge_vars(other_vars)

--- a/lib/drill/version.rb
+++ b/lib/drill/version.rb
@@ -1,3 +1,3 @@
 module Drill
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Now we can pass `skip_delivery` param for mail, for example:
```ruby
class ExampleMailer < Drill::Mailer
  def welcome_email(user)
    @user = user

    mail(from_email: 'from@example.com', 
         from_name: 'example',
         to: @user.email, 
         template_name: 'example_template',
         skip_delivery: skip_delivery?)
  end

  private

  def skip_delivery?
    !@user.subscribed?
  end
end
```